### PR TITLE
fix option shortcut for Host

### DIFF
--- a/src/Metfan/RabbitSetup/Command/ConfigExpertCommand.php
+++ b/src/Metfan/RabbitSetup/Command/ConfigExpertCommand.php
@@ -37,7 +37,7 @@ class ConfigExpertCommand extends Command
             ->setName('rsetup:config:expert')
             ->setDescription('Apply configuration file to RabbitMQ')
             ->addArgument('configFile', InputArgument::REQUIRED, 'Configuration file')
-            ->addOption('host', 'h', InputOption::VALUE_REQUIRED, 'Override host config', null)
+            ->addOption('host', null, InputOption::VALUE_REQUIRED, 'Override host config', null)
             ->addOption('port', null, InputOption::VALUE_REQUIRED, 'Override port config', null)
             ->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'Override user config', null)
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'Override password config', null);


### PR DESCRIPTION
remove `h` shortcut on Host option. Already use for help.