### PR TITLE
automaticaly set user after create vhost

### DIFF
--- a/src/Metfan/RabbitSetup/Http/ClientPool.php
+++ b/src/Metfan/RabbitSetup/Http/ClientPool.php
@@ -113,6 +113,21 @@ class ClientPool
     }
 
     /**
+     * Return username from a connection
+     *
+     * @param $connectionName
+     * @return mixed
+     */
+    public function getUserByConnectionName($connectionName)
+    {
+        if (!array_key_exists($connectionName, $this->connections)) {
+            throw new \OutOfRangeException(sprintf('Expected connection %s doesn\'t exists', $connectionName));
+        }
+
+        return $this->connections[$connectionName]['user'];
+    }
+
+    /**
      * create a client
      *
      * @param $name

--- a/src/Metfan/RabbitSetup/Manager/RabbitMq/VhostManager.php
+++ b/src/Metfan/RabbitSetup/Manager/RabbitMq/VhostManager.php
@@ -85,6 +85,20 @@ class VhostManager
             []);
         $this->logger->info(sprintf('Create vhost: <info>%s</info>', urldecode($vhostName)));
 
+        //add permissions of connection user to vhost
+        $user = $this->clientPool->getUserByConnectionName($configuration['connection']);
+        $client->query(
+            ClientInterface::METHOD_PUT,
+            sprintf('/api/permissions/%s/%s', $vhostName, urlencode($user)),
+            ["configure" => ".*", "write" => ".*", "read" => ".*"]);
+        $this->logger->info(
+            sprintf(
+                'Add permissions to vhost: <info>%s</info> for user: <info>%s</info>',
+                urldecode($vhostName),
+                $user
+            )
+        );
+
         //process parameters
         if (isset($configuration['parameters']) && count($configuration['parameters'])) {
 

--- a/src/Metfan/RabbitSetup/Tests/Command/ConfigExpertCommandTest.php
+++ b/src/Metfan/RabbitSetup/Tests/Command/ConfigExpertCommandTest.php
@@ -63,14 +63,19 @@ class ConfigExpertCommandTest extends \PHPUnit_Framework_TestCase
     public function testBasic()
     {
         $this->client
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('query')
             ->with('PUT', '/api/vhosts/%2F', []);
+
+        $this->client
+            ->expects($this->at(1))
+            ->method('query')
+            ->with('PUT', '/api/permissions/%2F/guest', ["configure" => ".*", "write" => ".*", "read" => ".*"]);
 
         $tester = new CommandTester($this->command);
         $tester->execute(['configFile' => 'Parser/fixture/config.yml']);
 
-        $this->assertEquals("<>[info] Create vhost: /\n", $tester->getDisplay(true));
+        $this->assertEquals("<>[info] Create vhost: /\n<>[info] Add permissions to vhost: / for user: guest\n", $tester->getDisplay(true));
         $this->assertEquals(0, $tester->getStatusCode());
     }
 }

--- a/src/Metfan/RabbitSetup/Tests/Http/ClientPoolTest.php
+++ b/src/Metfan/RabbitSetup/Tests/Http/ClientPoolTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Metfan\RabbitSetup\Tests\Http;
+
 use Metfan\RabbitSetup\Http\ClientPool;
 
 
@@ -42,9 +43,8 @@ class ClientPoolTest extends \PHPUnit_Framework_TestCase
             ->willReturn('client1');
 
         $pool->setConnections(['ulrich' => ['info']]);
-        $client1 = $pool->getClientByName('ulrich');
 
-        $this->assertEquals($client1, $pool->getClientByName('ulrich'));
+        $this->assertEquals('client1', $pool->getClientByName('ulrich'));
     }
 
     public function testOverride()
@@ -74,5 +74,22 @@ class ClientPoolTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($pool, $pool->overrideUser('newUser'));
         $this->assertEquals($pool, $pool->overridePassword('newPassword'));
         $pool->getClientByName('ulrich');
+    }
+
+    public function testGetUserByConnectionNameFailed()
+    {
+        $pool = new ClientPool($this->factory);
+
+        $this->setExpectedException('\OutOfRangeException');
+        $pool->getUserByConnectionName('ulrich');
+    }
+
+    public function testGetUserByConnectionName()
+    {
+        $pool = new ClientPool($this->factory);
+
+        $pool->setConnections(['ulrich' => ['user' => 'guest']]);
+
+        $this->assertEquals('guest', $pool->getUserByConnectionName('ulrich'));
     }
 }

--- a/src/Metfan/RabbitSetup/Tests/Manager/RabbitMq/VhostManagerTest.php
+++ b/src/Metfan/RabbitSetup/Tests/Manager/RabbitMq/VhostManagerTest.php
@@ -76,7 +76,7 @@ class VhostManagerTest extends \PHPUnit_Framework_TestCase
             ->willReturn($this->client);
 
         $this->client
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('query')
             ->with(
                 ClientInterface::METHOD_PUT,
@@ -85,9 +85,28 @@ class VhostManagerTest extends \PHPUnit_Framework_TestCase
             );
 
         $this->logger
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('info')
             ->with('Create vhost: <info>/</info>');
+
+        $this->clientPool
+            ->expects($this->once())
+            ->method('getUserByConnectionName')
+            ->willReturn('guest');
+
+        $this->client
+            ->expects($this->at(1))
+            ->method('query')
+            ->with(
+                ClientInterface::METHOD_PUT,
+                '/api/permissions/%2F/guest',
+                ["configure" => ".*", "write" => ".*", "read" => ".*"]
+            );
+
+        $this->logger
+            ->expects($this->at(1))
+            ->method('info')
+            ->with('Add permissions to vhost: <info>/</info> for user: <info>guest</info>');
 
         return $manager;
     }


### PR DESCRIPTION
If vhost doesn't exist we create it. But the rest of the process failed because by default no one can access to vhost.
The idea is to set permission for the user used in the connection to create the vhost. So the process will continue and don't need manual user permission setting.